### PR TITLE
Add ability to stop kudos minting and cloning

### DIFF
--- a/contracts/Kudos.sol
+++ b/contracts/Kudos.sol
@@ -19,6 +19,15 @@ contract Kudos is ERC721Token("KudosToken", "KDO"), Ownable {
 
     Kudo[] public kudos;
     uint256 public cloneFeePercentage = 10;
+    bool public isMintable = true;
+
+    modifier mintable {
+        require(
+            isMintable == true,
+            "New kudos are no longer mintable on this contract.  Please see KUDOS_CONTRACT_MAINNET at http://gitcoin.co/l/gcsettings for latest address."
+        );
+        _;
+    }
 
     /// @dev mint(): Mint a new Gen0 Kudos.  These are the tokens that other Kudos will be "cloned from".
     /// @param _to Address to mint to.
@@ -26,7 +35,7 @@ contract Kudos is ERC721Token("KudosToken", "KDO"), Ownable {
     /// @param _numClonesAllowed Maximum number of times this Kudos is allowed to be cloned.
     /// @param _tokenURI A URL to the JSON file containing the metadata for the Kudos.  See metadata.json for an example.
     /// @return the tokenId of the Kudos that has been minted.  Note that in a transaction only the tx_hash is returned.
-    function mint(address _to, uint256 _priceFinney, uint256 _numClonesAllowed, string _tokenURI) public payable onlyOwner returns (uint256 tokenId) {
+    function mint(address _to, uint256 _priceFinney, uint256 _numClonesAllowed, string _tokenURI) public payable mintable onlyOwner returns (uint256 tokenId) {
         uint256 _numClonesInWild = 0;
         uint256 _clonedFromId = 0;
 
@@ -55,7 +64,7 @@ contract Kudos is ERC721Token("KudosToken", "KDO"), Ownable {
     /// @param _to The address to clone to.
     /// @param _tokenId The token id of the Kudos to clone and transfer.
     /// @param _numClonesRequested Number of clones to generate.
-    function clone(address _to, uint256 _tokenId, uint256 _numClonesRequested) public payable {
+    function clone(address _to, uint256 _tokenId, uint256 _numClonesRequested) public payable mintable {
         // Grab existing Kudo blueprint
         Kudo memory _kudo = kudos[_tokenId];
         uint256 cloningCost  = _kudo.priceFinney * 10**15 * _numClonesRequested;
@@ -123,6 +132,14 @@ contract Kudos is ERC721Token("KudosToken", "KDO"), Ownable {
             _cloneFeePercentage >= 0 && _cloneFeePercentage <= 100,
             "Invalid range for cloneFeePercentage.  Must be between 0 and 100.");
         cloneFeePercentage = _cloneFeePercentage;
+    }
+
+    /// @dev setMintable(): set the isMintable public variable.  When set to `false`, no new 
+    ///                     kudos are allowed to be minted or cloned.  However, all of already
+    ///                     existing kudos will remain unchanged.
+    /// @param _isMintable flag for the mintable function modifier.
+    function setMintable(bool _isMintable) public onlyOwner {
+        isMintable = _isMintable;
     }
 
     /// @dev setPrice(): Update the Kudos listing price.

--- a/test/kudos.js
+++ b/test/kudos.js
@@ -210,7 +210,7 @@ contract("KudosTest", async(accounts) => {
     }
   })
 
-  it.only("should be able to stop all minting and cloning on the contract", async () => {
+  it("should be able to stop all minting and cloning on the contract", async () => {
     let instance = await Kudos.deployed();
     await instance.mint(mintAddress, priceFinney, numClonesAllowed, tokenURI, {"from": accounts[0]});
     let kudos_id = (await instance.getLatestId()).toNumber();

--- a/test/kudos.js
+++ b/test/kudos.js
@@ -210,4 +210,29 @@ contract("KudosTest", async(accounts) => {
     }
   })
 
+  it.only("should be able to stop all minting and cloning on the contract", async () => {
+    let instance = await Kudos.deployed();
+    await instance.mint(mintAddress, priceFinney, numClonesAllowed, tokenURI, {"from": accounts[0]});
+    let kudos_id = (await instance.getLatestId()).toNumber();
+    let numClones = 1;
+    // Make sure clonging works also
+    await instance.clone(accounts[1], kudos_id, numClones, {"from": accounts[1], "value": priceWeiBN});
+    // Turn minting off
+    await instance.setMintable(false, {"from": accounts[0]});
+    // Cloning should no longer work
+    try {
+      await instance.clone(accounts[1], kudos_id, numClones, {"from": accounts[1], "value": priceWeiBN});
+      assert.fail();
+    } catch (err) {
+      assert.ok(err);
+    }
+    // Minting should no longer work
+    try {
+      await instance.mint(mintAddress, priceFinney, numClonesAllowed, tokenURI, {"from": accounts[0]});
+      assert.fail();
+    } catch (err) {
+      assert.ok(err);
+    }
+  })
+
 });


### PR DESCRIPTION
Adds a new public variable `isMintable` that can be set using the `setMintable` function.  By default `isMintable` is set to `true`, but if its set to `false`, no one can mint or clone new kudos.

The reason for adding this is so that we have a way to deprecate old contracts.  When we want to use a new kudos contract, the process will be:

- Run `setMintable(false)` on the contract
- Deploy new contract to mainnet.  Update `KUDOS_CONTRACT_MAINNET` address in settings.py and abi.js.

The old kudos will still be viewable in gitcoin, but the marketplace will only contain the kudos on the newest contract.

## Testing
A new test was added for this.  To run all the tests, `truffle test --network test`.